### PR TITLE
Draft: small fix for loading holidays correctly

### DIFF
--- a/js/kronolith.js
+++ b/js/kronolith.js
@@ -3853,8 +3853,17 @@ KronolithCore = {
             data.owner_input = null;
         }
         if (data.type == 'holiday') {
-            this.insertCalendarInList('holiday', data.driver, Kronolith.conf.calendars.holiday[data.driver]);
-            this.toggleCalendar('holiday', data.driver);
+			// checking if a holiday is already in the list
+            let check = this.getCalendarList(data.type).textContent.replace(/[^\w\s]/gi, '');
+            if (check === data.driver){
+                // if so: only toggle the calendar
+                this.toggleCalendar('holiday', data.driver);
+            }
+            else {
+                // if not so: add the calendar to the list
+                this.insertCalendarInList('holiday', data.driver, Kronolith.conf.calendars.holiday[data.driver]);
+                this.toggleCalendar('holiday', data.driver);
+            }
             form.down('.kronolithCalendarSave').enable();
             this.closeRedBox();
             this.go(this.lastLocation);

--- a/js/kronolith.js
+++ b/js/kronolith.js
@@ -3854,8 +3854,8 @@ KronolithCore = {
         }
         if (data.type == 'holiday') {
 			// checking if a holiday is already in the list
-            let check = this.getCalendarList(data.type).textContent.replace(/[^\w\s]/gi, '');
-            if (check === data.driver){
+            let check = this.getCalendarList(data.type).textContent;
+            if (check.includes(data.driver)){
                 // if so: only toggle the calendar
                 this.toggleCalendar('holiday', data.driver);
             }

--- a/js/kronolith.js
+++ b/js/kronolith.js
@@ -3853,17 +3853,21 @@ KronolithCore = {
             data.owner_input = null;
         }
         if (data.type == 'holiday') {
-			// checking if a holiday is already in the list
-            let check = this.getCalendarList(data.type).textContent;
-            if (check.includes(data.driver)){
-                // if so: only toggle the calendar
+
+			// getting the holidays that are listed but unselected
+            let check = this.getCalendarList(data.type);          
+            let checklist = check.select('span.horde-resource-off').map(
+                item => item = item.textContent
+            );
+            
+            // checking if the new calendar is in the unselected list
+            if (checklist.indexOf(data.driver) > -1){
                 this.toggleCalendar('holiday', data.driver);
-            }
-            else {
-                // if not so: add the calendar to the list
+            }else{
                 this.insertCalendarInList('holiday', data.driver, Kronolith.conf.calendars.holiday[data.driver]);
                 this.toggleCalendar('holiday', data.driver);
             }
+
             form.down('.kronolithCalendarSave').enable();
             this.closeRedBox();
             this.go(this.lastLocation);


### PR DESCRIPTION
Problem:
One  can add a holiday calendar, then untoggles. After this it is possible to add the same calendar again. One can repeat this process for an infinite untoggled identical holliday calendars.

Solution:
Adds a simple check.

Note: This does not solve the fact that holiday calendars have to be installed by pear, as mentioned in this [issue](https://github.com/maintaina-com/kronolith/issues/7).

