### PR TITLE
Teams calendar xmlfix

### DIFF
--- a/lib/Event/Sql.php
+++ b/lib/Event/Sql.php
@@ -283,6 +283,21 @@ class Kronolith_Event_Sql extends Kronolith_Event
             $properties['event_baseid'] = '';
             $properties['event_exceptionoriginaldate'] = null;
         }
+
+        foreach ($this->otherAttributes as $key => $attribute) {
+            // added by boekhorst as a quickfix
+            // TODO: is it necessary to have this html info saved? If so: find a way to convert it to some format that is saveable for sql.
+            if (strpos($attribute['value'], '<html xmlns') === 0) {
+                $this->otherAttributes[$key]['value'] = "Html-xmlns format is too large, not being saved";
+            }
+            foreach ($attribute['values'] as $subKey => $value) {
+                if (strpos($value, '<html xmlns') === 0) {
+                    $this->otherAttributes[$key]['values'][$subKey] = "Html-xmlns format is too large, not being saved";
+                }
+            }
+        }
+        
+        
         $properties['other_attributes'] = json_encode($this->otherAttributes);
 
         return $properties;

--- a/lib/Event/Sql.php
+++ b/lib/Event/Sql.php
@@ -284,15 +284,18 @@ class Kronolith_Event_Sql extends Kronolith_Event
             $properties['event_exceptionoriginaldate'] = null;
         }
 
+        
         foreach ($this->otherAttributes as $key => $attribute) {
             // added by boekhorst as a quickfix
             // TODO: is it necessary to have this html info saved? If so: find a way to convert it to some format that is saveable for sql.
-            if (strpos($attribute['value'], '<html xmlns') === 0) {
-                $this->otherAttributes[$key]['value'] = "Html-xmlns format is too large, not being saved";
-            }
-            foreach ($attribute['values'] as $subKey => $value) {
-                if (strpos($value, '<html xmlns') === 0) {
-                    $this->otherAttributes[$key]['values'][$subKey] = "Html-xmlns format is too large, not being saved";
+            if ($attribute['name'] === "X-ALT-DESC"){
+                if (strpos($attribute['value'], '<html xmlns') === 0) {
+                    $this->otherAttributes[$key]['value'] = "Html of Teams or Outlook is too large, not being saved";
+                }
+                foreach ($attribute['values'] as $subKey => $value) {
+                    if (strpos($value, '<html xmlns') === 0) {
+                        $this->otherAttributes[$key]['values'][$subKey] = "Html of Teams or Outlook is too large, not being saved";
+                    }
                 }
             }
         }

--- a/lib/Event/Sql.php
+++ b/lib/Event/Sql.php
@@ -283,23 +283,6 @@ class Kronolith_Event_Sql extends Kronolith_Event
             $properties['event_baseid'] = '';
             $properties['event_exceptionoriginaldate'] = null;
         }
-
-        
-        foreach ($this->otherAttributes as $key => $attribute) {
-            // added by boekhorst as a quickfix
-            // TODO: is it necessary to have this html info saved? If so: find a way to convert it to some format that is saveable for sql.
-            if ($attribute['name'] === "X-ALT-DESC"){
-                if (strpos($attribute['value'], '<html xmlns') === 0) {
-                    $this->otherAttributes[$key]['value'] = "Html of Teams or Outlook is too large, not being saved";
-                }
-                foreach ($attribute['values'] as $subKey => $value) {
-                    if (strpos($value, '<html xmlns') === 0) {
-                        $this->otherAttributes[$key]['values'][$subKey] = "Html of Teams or Outlook is too large, not being saved";
-                    }
-                }
-            }
-        }
-        
         
         $properties['other_attributes'] = json_encode($this->otherAttributes);
 

--- a/migration/29_kronolith_other_attributes_typechange.php
+++ b/migration/29_kronolith_other_attributes_typechange.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Copyright 2020-2021 Horde LLC (http://www.horde.org/)
+ * Copyright 2022-2023 Horde LLC (http://www.horde.org/)
  *
  * See the enclosed file LICENSE for license information (GPL). If you
  * did not receive this file, see http://www.horde.org/licenses/gpl.
  *
- * @author   Ralf Lang <lang@b1-systems.de>
+ * @author   Rafael te Boekhorst <boekhorst@b1-systems.de>
  * @category Horde
  * @license  http://www.horde.org/licenses/gpl GPL
  * @package  Kronolith
@@ -24,9 +24,8 @@ class KronolithOtherAttributesTypechange extends Horde_Db_Migration_Base
          * for the other_attributes field.
          */
 
-        $t = $this->_connection->table('kronolith_events');
-        $cols = $t->getColumns();
-        if (!in_array('other_attributes', array_keys($cols))) {
+        $columns = $this->columns('kronolith_events');
+        if (in_array('other_attributes', array_keys($columns))) {
             $this->changeColumn('kronolith_events', 'other_attributes', 'mediumtext', ['default' => '[]']);
         }
     }
@@ -36,6 +35,9 @@ class KronolithOtherAttributesTypechange extends Horde_Db_Migration_Base
     */
     public function down()
     {
-        $this->changeColumn('kronolith_events', 'other_attributes', 'text', ['default' => '[]']);
+        $columns = $this->columns('kronolith_events');
+        if (in_array('other_attributes', array_keys($columns))) {
+            $this->changeColumn('kronolith_events', 'other_attributes', 'text', ['default' => '[]']);
+        }
     }
 }

--- a/migration/29_kronolith_other_attributes_typechange.php
+++ b/migration/29_kronolith_other_attributes_typechange.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Copyright 2020-2021 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (GPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/gpl.
+ *
+ * @author   Ralf Lang <lang@b1-systems.de>
+ * @category Horde
+ * @license  http://www.horde.org/licenses/gpl GPL
+ * @package  Kronolith
+ */
+
+class KronolithOtherAttributesTypechange extends Horde_Db_Migration_Base
+{
+    /**
+     * Upgrade.
+     */
+    public function up()
+    {
+        /**
+         * NOTE: Because of a size-related issue with "X-ALT-DESC"
+         * we decided to change the datatype text to mediumtext
+         * for the other_attributes field.
+         */
+
+        $t = $this->_connection->table('kronolith_events');
+        $cols = $t->getColumns();
+        if (!in_array('other_attributes', array_keys($cols))) {
+            $this->changeColumn('kronolith_events', 'other_attributes', 'mediumtext', ['default' => '[]']);
+        }
+    }
+
+    /**
+    * Downgrade
+    */
+    public function down()
+    {
+        $this->changeColumn('kronolith_events', 'other_attributes', 'text', ['default' => '[]']);
+    }
+}


### PR DESCRIPTION
large '<html xmlns....'-entries into "X-ALT-DESC" make it impossible to import calendars for Teams (Microsoft) events.

I removed those specific entries and now team events can be added.

Question:
should kronotlith simpy check for xml entries and delete them for all other_attributes?